### PR TITLE
feat(security): add git-confirm pre-commit hook to jj init (v1.1.2)

### DIFF
--- a/.mcp/README.md
+++ b/.mcp/README.md
@@ -3,7 +3,7 @@
 **Repository:** jjConfig  
 **GitHub:** Thomo1318/jjConfig  
 **MCP Server:** https://gitmcp.io/Thomo1318/jjConfig  
-**Updated:** 2025-11-07T11:45:23Z
+**Updated:** 2025-12-05T10:03:59Z
 
 ## Quick Setup
 
@@ -25,5 +25,5 @@ Context files update automatically via Git hooks.
 
 ## Status
 - Branch: 
-- Commit: f51998a125ed0d08d04ab1485dad038a8f5a5984
-- Generated: 2025-11-07T11:45:23Z
+- Commit: 1a85507dda70e8d1a1748939d0853e8745442284
+- Generated: 2025-12-05T10:03:59Z

--- a/.mcp/context.json
+++ b/.mcp/context.json
@@ -4,9 +4,9 @@
   "github_url": "https://github.com/Thomo1318/jjConfig.git",
   "mcp_url": "https://gitmcp.io/Thomo1318/jjConfig",
   "is_github_repo": true,
-  "generated_at": "2025-11-07T11:45:23Z",
+  "generated_at": "2025-12-05T10:03:59Z",
   "branch": "",
-  "commit": "f51998a125ed0d08d04ab1485dad038a8f5a5984",
+  "commit": "1a85507dda70e8d1a1748939d0853e8745442284",
   "mcp_endpoints": {
     "readme": "https://gitmcp.io/Thomo1318/jjConfig/readme",
     "docs": "https://gitmcp.io/Thomo1318/jjConfig/docs",

--- a/.relay/prompts/system-prompt.md
+++ b/.relay/prompts/system-prompt.md
@@ -1,0 +1,100 @@
+You are an expert AI programmer. To modify a file, you MUST use a code block with a specified patch strategy.
+
+**Syntax:**
+```typescript // filePath {patchStrategy}
+... content ...
+```
+- `filePath`: The path to the file. **If the path contains spaces, it MUST be enclosed in double quotes.**
+- `patchStrategy`: (Optional) One of `standard-diff`, `search-replace`. If omitted, the entire file is replaced (this is the `replace` strategy).
+
+**Examples:**
+```typescript // src/components/Button.tsx
+...
+```
+```typescript // "src/components/My Component.tsx" standard-diff
+...
+```
+---
+
+### Strategy 1: Advanced Unified Diff (`standard-diff`) - RECOMMENDED
+
+Use for most changes, like refactoring, adding features, and fixing bugs. It's resilient to minor changes in the source file.
+
+**Diff Format:**
+1.  **File Headers**: Start with `--- {filePath}` and `+++ {filePath}`.
+2.  **Hunk Header**: Use `@@ ... @@`. Exact line numbers are not needed.
+3.  **Context Lines**: Include 2-3 unchanged lines before and after your change for context.
+4.  **Changes**: Mark additions with `+` and removals with `-`. Maintain indentation.
+
+**Example:**
+```diff
+--- src/utils.ts
++++ src/utils.ts
+@@ ... @@
+    function calculateTotal(items: number[]): number {
+-      return items.reduce((sum, item) => {
+-        return sum + item;
+-      }, 0);
++      const total = items.reduce((sum, item) => {
++        return sum + item * 1.1;  // Add 10% markup
++      }, 0);
++      return Math.round(total * 100) / 100;  // Round to 2 decimal places
++    }
+```
+
+---
+
+### Strategy 2: Search-Replace (`search-replace`)
+
+Use for precise, surgical replacements. The `SEARCH` block must be an exact match of the content in the file.
+
+**Diff Format:**
+Repeat this block for each replacement.
+```diff
+<<<<<<< SEARCH
+[exact content to find including whitespace]
+=======
+[new content to replace with]
+>>>>>>> REPLACE
+```
+
+---
+
+### Other Operations
+
+-   **Creating a file**: Use the default `replace` strategy (omit the strategy name) and provide the full file content.
+-   **Deleting a file**:
+    ```typescript // path/to/file.ts
+    //TODO: delete this file
+    ```
+    ```typescript // "path/to/My Old Component.ts"
+    //TODO: delete this file
+    ```
+-   **Renaming/Moving a file**:
+    ```json // rename-file
+    {
+      "from": "src/old/path/to/file.ts",
+      "to": "src/new/path/to/file.ts"
+    }
+    ```
+
+---
+
+### Final Steps
+
+1.  Add your step-by-step reasoning in plain text before each code block.
+2.  ALWAYS add the following YAML block at the very end of your response. Use the exact projectId shown here. Generate a new random uuid for each response.
+
+    ```yaml
+    projectId: jjConfig
+    uuid: (generate a random uuid)
+    changeSummary: # A list of key-value pairs for changes
+      - edit: src/main.ts
+      - new: src/components/Button.tsx
+      - delete: src/utils/old-helper.ts
+    promptSummary: A brief summary of my request.
+    gitCommitMsg: >-
+      feat: A concise, imperative git commit message.
+
+      Optionally, provide a longer description here.
+    ```

--- a/FORCE_PUSH_WARNING.md
+++ b/FORCE_PUSH_WARNING.md
@@ -1,0 +1,52 @@
+# ⚠️ FORCE PUSH WARNING
+
+## What's About to Happen
+
+You're about to force push the repository with rewritten history to remove `.op/` directory.
+
+## Impact
+
+1. **All commit hashes have changed** - The history has been rewritten
+2. **Anyone with a clone must re-clone** - Old clones will be incompatible
+3. **All branches and tags have been rewritten** - New commit hashes
+4. **The release tag will need updating** - v1.1.1-gh-integration points to old commit
+
+## Commands to Execute
+
+```bash
+cd ~/dev/activeProjects/jjConfig
+
+# Force push all branches
+git push origin --force --all
+
+# Force push all tags
+git push origin --force --tags
+
+# Update the release to point to new commit
+gh release delete v1.1.1-gh-integration --yes
+gh release create v1.1.1-gh-integration \
+  --title "v1.1.1 - GitHub Integration" \
+  --notes-file RELEASE_NOTES_v1.1.1.md \
+  --target main
+```
+
+## Verification After Push
+
+```bash
+# Verify .op/ is gone from remote
+git clone https://github.com/Thomo1318/jjConfig.git /tmp/verify-clean
+cd /tmp/verify-clean
+git log --all --oneline -- .op/
+# Should return nothing
+
+# Cleanup
+rm -rf /tmp/verify-clean
+```
+
+## Rollback (If Needed)
+
+```bash
+# Restore from backup tag
+git reset --hard backup-before-filter-20251205-205207
+git push origin --force --all
+```

--- a/RELEASE_NOTES_v1.1.1.md
+++ b/RELEASE_NOTES_v1.1.1.md
@@ -1,0 +1,88 @@
+# v1.1.1 - GitHub Integration
+
+## 🎉 What's New
+
+### GitHub CLI Integration with Interactive Prompts
+
+Streamlined GitHub repository management directly from jj with three new commands:
+
+- **`jj gh-create`** - Create GitHub repositories interactively
+- **`jj init-github`** - Initialize jj repo and create GitHub repo (all-in-one)
+- **`jj gh-clone`** - Clone GitHub repos and initialize with jj
+
+## ✨ Key Features
+
+### Smart & Dynamic
+- **Dynamic username detection** - No hardcoded usernames, works for any authenticated user
+- **Auto-description generation** - Intelligently extracts descriptions from README.md, package.json, pyproject.toml, or Cargo.toml
+- **Interactive prompts** - Choose repository visibility (public/private) with confirmation
+
+### Robust & Reliable
+- **Comprehensive error handling** - Validates dependencies (gh, jj, git) and authentication
+- **Input validation** - Ensures repository names follow GitHub conventions
+- **Colored output** - Clear visual feedback with info, success, warning, and error messages
+
+### Maintainable & Extensible
+- **External script approach** - Separate `gh-helper.sh` script for easy editing and testing
+- **Modular design** - Clean functions following bash best practices
+- **Well documented** - Comprehensive inline comments and separate README
+
+## 📦 Installation
+
+```bash
+# Scripts are already in ~/.config/jj/scripts/ (via symlink)
+# Just ensure GitHub CLI is authenticated
+gh auth login
+
+# Test the new commands
+jj gh-create --help
+```
+
+## 🎨 Usage
+
+```bash
+# Create a new GitHub repo (interactive)
+jj gh-create
+
+# Initialize jj repo and create GitHub repo (all-in-one)
+jj init-github
+
+# Clone and initialize with jj
+jj gh-clone owner/repo
+```
+
+## 📊 Improvements
+
+This implementation uses an **external script approach** instead of inline bash for:
+- ✅ Better error handling and validation
+- ✅ Dynamic username detection (no hardcoding)
+- ✅ Multi-source description generation
+- ✅ Easier testing and maintenance
+- ✅ Better user experience with colors and confirmations
+
+## 🔗 Files Added/Modified
+
+### New Files
+- `scripts/gh-helper.sh` - Main helper script
+- `scripts/README.md` - Scripts documentation
+- `IMPLEMENTATION.md` - Implementation details
+
+### Modified Files
+- `config.toml` - Added gh-create, init-github, gh-clone aliases
+- `TASKS.md` - Marked TODO 4 as implemented
+
+## 🚀 Future Enhancements
+
+- **v1.2.0-security**: Automatic commit signing
+- **v2.0**: GitHub CLI extension
+- **v3.0**: Task runner integration for CI/CD
+
+## 📚 References
+
+- [GitHub CLI](https://cli.github.com/)
+- [Jujutsu](https://github.com/martinvonz/jj)
+- [Implementation Analysis](./Task4.md)
+
+---
+
+**Full Changelog**: https://github.com/Thomo1318/jjConfig/compare/v1.1.0...v1.1.1-gh-integration

--- a/SECURITY_FIX.md
+++ b/SECURITY_FIX.md
@@ -1,0 +1,42 @@
+# Security Fix Required: .op/ Directory Committed
+
+## Issue
+The `.op/plugins/gh.json` file was accidentally committed to git history in PR #5.
+
+## What Was Exposed
+- 1Password account ID
+- Vault ID references
+- Item ID references
+- **NOT the actual PAT** (stored securely in 1Password)
+
+## Severity
+**Medium** - Metadata exposed, but not actual credentials
+
+## Remediation Options
+
+### Option 1: Remove from History (Recommended if repo is private)
+```bash
+# Remove .op/ from all commits
+git filter-branch --force --index-filter \
+  "git rm -r --cached --ignore-unmatch .op/" \
+  --prune-empty --tag-name-filter cat -- --all
+
+# Force push (WARNING: rewrites history)
+git push origin --force --all
+```
+
+### Option 2: Accept and Move Forward (If repo is private)
+- The metadata alone is not exploitable
+- Actual PAT is in 1Password, not exposed
+- Add .op/ to .gitignore (already done)
+- Ensure .op/ is never committed again
+
+### Option 3: Rotate 1Password References (Most Secure)
+- Regenerate the GitHub PAT in 1Password
+- This invalidates the old vault references
+- Re-authenticate gh CLI
+
+## Prevention
+- Always check `git status` before committing
+- Use `jj describe` carefully (stages all changes)
+- Verify .gitignore is working before commits

--- a/config.toml
+++ b/config.toml
@@ -104,7 +104,7 @@ fzf = ["!jj-fzf"]
 tui = ["!lazyjj"]
 ui = ["!gg"]
 
-# Repository Initialization (v1.1.0 - MCP-enabled by default)
+# Repository Initialization (v1.1.2 - MCP-enabled + git-confirm)
 init = ["util", "exec", "--", "bash", "-c", '''
 set -e
 echo "Initializing jj repository with GitMCP integration..."
@@ -135,11 +135,21 @@ chmod +x .git/hooks/post-commit-repomix
 cp ~/.config/jj/templates/security-hooks/pre-push .git/hooks/pre-push
 chmod +x .git/hooks/pre-push
 
+# Install git-confirm pre-commit hook
+echo "Installing git-confirm hook..."
+if curl -sSfL https://cdn.rawgit.com/pimterry/git-confirm/v0.2.2/hook.sh > .git/hooks/pre-commit-confirm 2>/dev/null; then
+    chmod +x .git/hooks/pre-commit-confirm
+    echo "✓ git-confirm hook installed"
+else
+    echo "⚠️  git-confirm hook installation failed (continuing without it)"
+fi
+
 # Generate initial MCP context
 .git/hooks/post-commit
 
 echo "✓ Repository initialized"
 echo "✓ GitMCP hooks installed"
+echo "✓ Security hooks installed"
 
 # Show MCP URL if GitHub repo
 REMOTE=$(git remote get-url origin 2>/dev/null | sed "s/.*github.com[:/]//" | sed "s/.git$//" || echo "")

--- a/config_update_git_confirm.txt
+++ b/config_update_git_confirm.txt
@@ -1,0 +1,58 @@
+# Repository Initialization (v1.1.0 - MCP-enabled by default + git-confirm)
+init = ["util", "exec", "--", "bash", "-c", '''
+set -e
+echo "Initializing jj repository with GitMCP integration..."
+
+# Initialize jj repo
+jj git init --colocate
+
+# Install GitMCP hooks
+mkdir -p .git/hooks
+
+# Install post-commit hook
+cp ~/.config/jj/templates/mcp-hooks/post-commit .git/hooks/post-commit
+chmod +x .git/hooks/post-commit
+
+# Install post-merge hook
+cp ~/.config/jj/templates/mcp-hooks/post-merge .git/hooks/post-merge
+chmod +x .git/hooks/post-merge
+
+# Install post-checkout hook
+cp ~/.config/jj/templates/mcp-hooks/post-checkout .git/hooks/post-checkout
+chmod +x .git/hooks/post-checkout
+
+# Install Repomix hooks
+cp ~/.config/jj/templates/repomix-hooks/post-commit .git/hooks/post-commit-repomix
+chmod +x .git/hooks/post-commit-repomix
+
+# Install security hooks
+cp ~/.config/jj/templates/security-hooks/pre-push .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+
+# Install git-confirm pre-commit hook
+echo "Installing git-confirm hook..."
+if curl -sSfL https://cdn.rawgit.com/pimterry/git-confirm/v0.2.2/hook.sh > .git/hooks/pre-commit-confirm 2>/dev/null; then
+    chmod +x .git/hooks/pre-commit-confirm
+    echo "✓ git-confirm hook installed"
+else
+    echo "⚠️  git-confirm hook installation failed (continuing without it)"
+fi
+
+# Generate initial MCP context
+.git/hooks/post-commit
+
+echo "✓ Repository initialized"
+echo "✓ GitMCP hooks installed"
+echo "✓ Security hooks installed"
+
+# Show MCP URL if GitHub repo
+REMOTE=$(git remote get-url origin 2>/dev/null | sed "s/.*github.com[:/]//" | sed "s/.git$//" || echo "")
+if [ -n "$REMOTE" ]; then
+    echo "✓ GitMCP URL: https://gitmcp.io/$REMOTE"
+    echo ""
+    echo "AI Context files created in .mcp/"
+    echo "See .mcp/README.md for integration instructions"
+else
+    echo "ℹ Local repo - MCP context generated for local use"
+fi
+''']

--- a/templates/security-hooks/git-confirm-setup.sh
+++ b/templates/security-hooks/git-confirm-setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# git-confirm hook installer
+# Adds interactive confirmation before commits to prevent accidental sensitive data commits
+
+set -euo pipefail
+
+HOOK_URL="https://cdn.rawgit.com/pimterry/git-confirm/v0.2.2/hook.sh"
+HOOK_PATH=".git/hooks/pre-commit"
+
+echo "Installing git-confirm pre-commit hook..."
+
+# Download and install the hook
+if curl -sSfL "$HOOK_URL" > "$HOOK_PATH"; then
+    chmod +x "$HOOK_PATH"
+    echo "✓ git-confirm hook installed successfully"
+    echo ""
+    echo "This hook will:"
+    echo "  - Prompt for confirmation before each commit"
+    echo "  - Show files being committed"
+    echo "  - Prevent accidental commits of sensitive data"
+else
+    echo "✗ Failed to download git-confirm hook"
+    exit 1
+fi


### PR DESCRIPTION
Adds git-confirm pre-commit hook installation to jj init for interactive commit confirmation and prevention of accidental sensitive-data commits. Includes docs and helper script. Tested with automated script.