### PR TITLE
fix(docs): add Relearn theme as Git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hugo-docs/themes/relearn"]
+	path = hugo-docs/themes/relearn
+	url = https://github.com/McShelby/hugo-theme-relearn.git


### PR DESCRIPTION
### **User description**
## Summary

Adds the Relearn theme as a proper Git submodule. The previous commits had the theme cloned locally but not registered as a submodule, causing CI to fail with:

```
ERROR failed to load modules: module "relearn" not found
```

## Verification

✅ Local build passed: **27 pages in 104ms**

## Changes

- Added `.gitmodules` with Relearn theme reference
- Registered `hugo-docs/themes/relearn` as submodule pointing to `https://github.com/McShelby/hugo-theme-relearn.git`


___

### **PR Type**
Bug fix


___

### **Description**
- Registers Relearn theme as Git submodule

- Fixes CI failure due to missing module

- Enables proper theme initialization in builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Build"] -- "requires" --> B["Relearn Theme Module"]
  C[".gitmodules"] -- "registers" --> B
  B -- "resolves" --> D["Successful Build"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitmodules</strong><dd><code>Add Relearn theme Git submodule configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.gitmodules

<ul><li>Added new <code>.gitmodules</code> configuration file<br> <li> Registered <code>hugo-docs/themes/relearn</code> as Git submodule<br> <li> Points to official Relearn theme repository at <br><code>https://github.com/McShelby/hugo-theme-relearn.git</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Thomo1318/jjConfig/pull/15/files#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

